### PR TITLE
(#8) Support opt-out of os.Args

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -57,7 +57,11 @@ func (c *cliInstance) Application() *fisk.Application {
 func (c *cliInstance) Run(ctx context.Context) error {
 	c.ctx, c.cancel = context.WithCancel(ctx)
 
-	c.cli.MustParseWithUsage(os.Args[1:])
+	args := os.Args[1:]
+	if c.opts.CustomArgsEnabled {
+		args = c.opts.CustomArgs
+	}
+	c.cli.MustParseWithUsage(args)
 
 	return nil
 }

--- a/options.go
+++ b/options.go
@@ -74,6 +74,8 @@ func (o roOptions) NatsNeySeedFile() string             { return o.opts.NatsNeyS
 func (o roOptions) NatsCredentialsFile() string         { return o.opts.NatsCredentialsFile }
 func (o roOptions) StartTime() time.Time                { return o.opts.StartTime }
 func (o roOptions) ConfigBucketPrefix() string          { return o.opts.ConfigBucketPrefix }
+func (o roOptions) CustomArgsEnabled() bool             { return o.opts.CustomArgsEnabled }
+func (o roOptions) CustomArgs() []string                { return o.opts.CustomArgs }
 
 func (o *Options) roCopy() *roOptions {
 	return &roOptions{*o}
@@ -120,6 +122,10 @@ type Options struct {
 	NoHostFacts bool `json:"no_host_facts,omitempty"`
 	// NoNetworkFacts disables built-in network interface facts gathering
 	NoNetworkFacts bool `json:"no_network_facts,omitempty"`
+
+	// os.Args opt-out https://github.com/choria-io/machine-room/issues/8
+	CustomArgsEnabled bool     `json:"-"`
+	CustomArgs        []string `json:"-"`
 
 	// Read only below...
 

--- a/server.go
+++ b/server.go
@@ -228,7 +228,7 @@ func (s *server) createServerNKey() error {
 
 func (s *server) provisionConfig(f string, bi *build.Info) (*config.Config, error) {
 	if !choria.FileExist(bi.ProvisionJWTFile()) {
-		return nil, fmt.Errorf("provisioming token not found in %s", bi.ProvisionJWTFile())
+		return nil, fmt.Errorf("provisioning token not found in %s", bi.ProvisionJWTFile())
 	}
 
 	err := s.createServerNKey()


### PR DESCRIPTION
Problem:
Cannot embed machine room as a cobra subcommand because fisk and cobra fight over os.Args

Solution:
Add a CustomArgs and CustomArgsEnabled machine room option to pass args through.

Result:
Machine room can run as a cobra subcommand:

```go
cmd := &cobra.Command{
  Args:               cobra.ArbitraryArgs,
  DisableFlagParsing: true,
  RunE: func(cmd *cobra.Command, args []string) error {
    app, _ := mr.New(mr.Options{
      CustomArgsEnabled: true,
      CustomArgs:        args,
    })
    return app.Run(cmd.Context())
  },
}
```

Closes: #8 